### PR TITLE
should allow /storm routing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules/
+*.swp
+

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   },
   "homepage": "https://github.com/lowellbander/shire#readme",
   "dependencies": {
-    "connect": "^3.4.0",
-    "serve-static": "^1.10.0"
+    "express": "^4.13.3",
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,5 +1,15 @@
-var connect = require('connect');
-var serveStatic = require('serve-static');
+var express = require('express');
+var app = express();
+
+app.get('/', function (req, res) {
+  res.sendFile(__dirname + '/index.html');
+});
+
+app.get('/storm', function (req, res) {
+  res.redirect('https://docs.google.com/forms/d/1fptj2N4_Mbyx-Ef2_LSDUdEMjlfZIJhRcly6BcsYmv0/viewform');
+});
+
 var port = process.env.PORT || 5000;
-console.log('server starting on port ' + port);
-connect().use(serveStatic(__dirname)).listen(port);
+console.log('Listening on port ', port);
+app.listen(port);
+


### PR DESCRIPTION
This should still return `index.html` when the usual route is hit, and should redirect to the google form when `/storm` is hit

s/o to @goom11
